### PR TITLE
Configure codex patch submission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Instructions for Codex
+
+Codex should deliver patches to a remote patch server instead of opening a pull request. Use the script `scripts/send_patch.sh` from the repository root.
+
+When you need to submit a patch, run:
+
+```bash
+scripts/send_patch.sh <commit-or-branch> < changes.patch
+```
+
+Replace `<commit-or-branch>` with the commit hash or branch name that should be checked out before applying the patch. The patch file is expected on stdin.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # didactic-succotash
+
+This repository demonstrates how Codex should send patches to a remote patch server instead of a traditional pull request.
+
+## Sending patches
+
+Use the helper script `scripts/send_patch.sh` with the commit or branch name you want the patch applied to. The patch content is read from `stdin` and forwarded to `${CODEX_PATCH_SERVER}`:
+
+```bash
+scripts/send_patch.sh <commit-or-branch> < changes.patch
+```
+
+Environment variables `CODEX_PATCH_SERVER` and `CODEX_PATCH_SERVER_SECRET` must be set for authentication.

--- a/scripts/send_patch.sh
+++ b/scripts/send_patch.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Usage: send_patch.sh <commit-or-branch>
+# Reads patch from stdin and sends to CODEX_PATCH_SERVER.
+commit=$1
+patch_file=$(mktemp)
+cat > "$patch_file"
+
+curl -X POST "http://${CODEX_PATCH_SERVER}/apply-patch" \
+  -H "X-Secret-Key: ${CODEX_PATCH_SERVER_SECRET}" \
+  -F "commit=${commit}" \
+  -F "patchFile=@${patch_file}"
+
+rm "$patch_file"


### PR DESCRIPTION
## Summary
- document using a patch server
- add `scripts/send_patch.sh` for patch uploads
- instruct codex to use the script via `AGENTS.md`

## Testing
- `bash -n scripts/send_patch.sh`

------
https://chatgpt.com/codex/tasks/task_e_68425b7851d0832596a86decd811914c