### PR TITLE
Add automatic patch sending hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ scripts/send_patch.sh <commit-or-branch> < changes.patch
 ```
 
 Environment variables `CODEX_PATCH_SERVER` and `CODEX_PATCH_SERVER_SECRET` must be set for authentication.
+
+## Automatic patch sending
+
+If the environment variable `CODEX_PATCH_SERVER_ENABLE` is set to `1`, you can
+send patches automatically after each commit. Link `scripts/post_commit_hook.sh`
+to `.git/hooks/post-commit`:
+
+```bash
+ln -s ../../scripts/post_commit_hook.sh .git/hooks/post-commit
+```
+
+The hook uses `scripts/send_patch.sh` to forward the latest commit to the
+configured `${CODEX_PATCH_SERVER}`.

--- a/scripts/post_commit_hook.sh
+++ b/scripts/post_commit_hook.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Post-commit hook that automatically sends the latest commit as a patch
+# to the Codex patch server when CODEX_PATCH_SERVER_ENABLE=1.
+
+set -euo pipefail
+
+if [ "${CODEX_PATCH_SERVER_ENABLE:-0}" = "1" ]; then
+    commit=$(git rev-parse HEAD)
+    git format-patch -1 --stdout "$commit" |
+        "$(dirname "$0")/send_patch.sh" "$commit"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/post_commit_hook.sh` to send latest commit as a patch if `CODEX_PATCH_SERVER_ENABLE=1`
- document how to enable the post-commit hook

## Testing
- `shellcheck scripts/post_commit_hook.sh`
- `shellcheck scripts/send_patch.sh`


------
https://chatgpt.com/codex/tasks/task_e_68426287279483259c2c4369cd22b10d